### PR TITLE
Update color thresholds for battery indicator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ fastlane/test_output
 iOSInjectionProject/
 
 *.app
+__pycache__/

--- a/BatteryReader.swift
+++ b/BatteryReader.swift
@@ -57,9 +57,12 @@ final class BatteryReader {
     /// Bewertungssymbol anhand Watt
     func rating(for watt: Double) -> String {
         switch watt {
-        case ..<2.0:  return "🟢"
-        case 2.0..<5: return "🟡"
-        default:      return "🔴"
+        case ..<5.0:
+            return "🟢"
+        case 5.0..<15.0:
+            return "🟡"
+        default:
+            return "🔴"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -4,3 +4,8 @@ Tracks Average and Current battery usage in the Menubar
  - sleepChecker, checks with a CLI tool if your Mac is ready to sleep
  - MacBattery.py returns your current power Usage on the Command Line and tells you if its too high
  - The Swift App allows Battery Tracking **directly** from the Menubar, giving status updates via Green, Orange or Red Dots and showing current Wattage and Battery %/hour
+
+Color indicator thresholds:
+- 🟢 <5 W (idle/light use)
+- 🟡 5–15 W (medium)
+- 🔴 >15 W (high)


### PR DESCRIPTION
## Summary
- adjust the power draw thresholds for the colored status dot
- document the new Watt thresholds
- ignore Python bytecode

## Testing
- `python3 -m py_compile MacBattery.py`


------
https://chatgpt.com/codex/tasks/task_e_684c82a416108325b3523e12a71b3b8b