### PR TITLE
Simplify drain rate algorithm and avoid doubles

### DIFF
--- a/AppDelegate.swift
+++ b/AppDelegate.swift
@@ -4,6 +4,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var statusItem: NSStatusItem?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApp.setActivationPolicy(.accessory)
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         statusItem?.button?.title = "🔋 Lade..."
 
@@ -20,7 +21,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
 
             if let avgDrain = BatteryHistory.shared.averageDrainPerHour() {
-                output += String(format: " | %.1f %%/h", avgDrain)
+                output += String(format: " | %.1f %%/h", Double(avgDrain))
             }
 
             self.statusItem?.button?.title = output.isEmpty ? "⚠️ n/a" : output

--- a/BatteryHistory.swift
+++ b/BatteryHistory.swift
@@ -13,25 +13,16 @@ final class BatteryHistory {
     func addSample(percentage: Int) {
         let sample = BatterySample(time: Date(), percentage: percentage)
         samples.append(sample)
-        if samples.count > 10 { samples.removeFirst() }
+        if samples.count > 5 { samples.removeFirst() }
     }
 
-    func averageDrainPerHour() -> Double? {
-        guard samples.count >= 2 else { return nil }
+    func averageDrainPerHour() -> Float? {
+        guard let first = samples.first, let last = samples.last, samples.count >= 2 else { return nil }
 
-        var rates: [Double] = []
+        let deltaPercent = Float(first.percentage - last.percentage)
+        let deltaTime = Float(last.time.timeIntervalSince(first.time)) / 3600.0
+        guard deltaTime > 0 else { return nil }
 
-        for i in 1..<samples.count {
-            let s1 = samples[i - 1]
-            let s2 = samples[i]
-            let deltaPercent = Double(s1.percentage - s2.percentage)
-            let deltaTime = s2.time.timeIntervalSince(s1.time) / 3600.0
-            if deltaTime > 0 {
-                rates.append(deltaPercent / deltaTime)
-            }
-        }
-
-        guard !rates.isEmpty else { return nil }
-        return rates.reduce(0, +) / Double(rates.count)
+        return deltaPercent / deltaTime
     }
 }

--- a/BatteryReader.swift
+++ b/BatteryReader.swift
@@ -52,7 +52,7 @@ final class BatteryReader {
             return nil
         }
 
-        return Int((Double(current) / Double(max)) * 100)
+        return Int((Float(current) / Float(max)) * 100)
     }
     /// Bewertungssymbol anhand Watt
     func rating(for watt: Double) -> String {

--- a/main.swift
+++ b/main.swift
@@ -2,5 +2,7 @@ import Cocoa
 
 let delegate = AppDelegate()
 let app = NSApplication.shared
+app.setActivationPolicy(.accessory)
 app.delegate = delegate
 app.run()
+


### PR DESCRIPTION
## Summary
- keep accessory activation policy to hide Dock icon
- compute percentage as `Int` instead of `Double`
- store only five recent samples and calculate drain rate using first and last sample
- display drain in menu bar with a single decimal place

## Testing
- `swiftc -o BatteryApp AppDelegate.swift BatteryReader.swift BatteryHistory.swift main.swift` *(fails: no such module 'Cocoa')*


------
https://chatgpt.com/codex/tasks/task_e_684c81eaeeb8832582e6c5ecd3a6bccc