### PR TITLE
Add watt history graph window

### DIFF
--- a/AppDelegate.swift
+++ b/AppDelegate.swift
@@ -2,11 +2,14 @@ import Cocoa
 
 class AppDelegate: NSObject, NSApplicationDelegate {
     var statusItem: NSStatusItem?
+    var detailWindow: NSWindow?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory)
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         statusItem?.button?.title = "🔋 Lade..."
+        statusItem?.button?.target = self
+        statusItem?.button?.action = #selector(showDetails)
 
         Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { _ in
             if let charge = BatteryReader.shared.readCharge() {
@@ -16,6 +19,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             var output = ""
 
             if let watt = BatteryReader.shared.readWatt() {
+                BatteryHistory.shared.addWattSample(watt)
                 let symbol = BatteryReader.shared.rating(for: watt)
                 output += String(format: "⚡ %.2f W %@", watt, symbol)
             }
@@ -25,6 +29,32 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
 
             self.statusItem?.button?.title = output.isEmpty ? "⚠️ n/a" : output
+            self.updateGraphIfNeeded()
         }
+    }
+
+    @objc func showDetails() {
+        let history = BatteryHistory.shared.wattHistory()
+        if detailWindow == nil {
+            let rect = NSRect(x: 0, y: 0, width: 300, height: 150)
+            detailWindow = NSWindow(contentRect: rect,
+                                   styleMask: [.titled, .closable],
+                                   backing: .buffered,
+                                   defer: false)
+            detailWindow?.isReleasedWhenClosed = false
+            detailWindow?.title = "Watt Verlauf"
+            detailWindow?.contentView = GraphView(frame: rect)
+        }
+        if let graph = detailWindow?.contentView as? GraphView {
+            graph.values = history
+        }
+        detailWindow?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    private func updateGraphIfNeeded() {
+        guard let window = detailWindow, window.isVisible,
+              let graph = window.contentView as? GraphView else { return }
+        graph.values = BatteryHistory.shared.wattHistory()
     }
 }

--- a/BatteryHistory.swift
+++ b/BatteryHistory.swift
@@ -6,17 +6,36 @@ struct BatterySample {
     let max: Int
 }
 
+struct WattSample {
+    let time: Date
+    let watt: Double
+}
+
 final class BatteryHistory {
     static let shared = BatteryHistory()
 
     private var samples: [BatterySample] = []
+    private var wattSamples: [WattSample] = []
     private let maxSamples = 30  // Erhöhe den Puffer auf 30 für längeren Verlauf
+    private let maxWattSamples = 60
 
     /// Neuen Messwert hinzufügen
     func addSample(charge: (current: Int, max: Int)) {
         let sample = BatterySample(time: Date(), charge: charge.current, max: charge.max)
         samples.append(sample)
         if samples.count > maxSamples { samples.removeFirst() }
+    }
+
+    /// Watt-Messwert hinzufügen
+    func addWattSample(_ watt: Double) {
+        let sample = WattSample(time: Date(), watt: watt)
+        wattSamples.append(sample)
+        if wattSamples.count > maxWattSamples { wattSamples.removeFirst() }
+    }
+
+    /// Aktuelle Verlaufsliste der Wattwerte
+    func wattHistory() -> [Double] {
+        return wattSamples.map { $0.watt }
     }
 
     /// Durchschnittlicher Entladeverbrauch in % pro Stunde

--- a/GraphView.swift
+++ b/GraphView.swift
@@ -1,0 +1,31 @@
+import Cocoa
+
+class GraphView: NSView {
+    var values: [Double] = [] {
+        didSet { needsDisplay = true }
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        NSColor.windowBackgroundColor.setFill()
+        dirtyRect.fill()
+        guard values.count > 1 else { return }
+        let path = NSBezierPath()
+        let maxVal = values.max() ?? 0
+        let minVal = values.min() ?? 0
+        let range = max(maxVal - minVal, 1)
+        for (index, value) in values.enumerated() {
+            let x = bounds.width * CGFloat(index) / CGFloat(values.count - 1)
+            let y = bounds.height * CGFloat((value - minVal) / range)
+            let point = NSPoint(x: x, y: y)
+            if index == 0 {
+                path.move(to: point)
+            } else {
+                path.line(to: point)
+            }
+        }
+        NSColor.systemBlue.setStroke()
+        path.lineWidth = 2
+        path.stroke()
+    }
+}


### PR DESCRIPTION
## Summary
- track historical watt samples alongside charge
- add GraphView to render a simple line graph
- show a window with watt history when clicking the menu bar item

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_684c9200b13c8325b14e421691d0b162