### PR TITLE
Add runtime tracking graph

### DIFF
--- a/BatteryHistory.swift
+++ b/BatteryHistory.swift
@@ -18,8 +18,13 @@ final class BatteryHistory {
     private var samples: [BatterySample] = []
     private var powerSamples: [PowerSample] = []
     private var drainHistory: [Double] = []
+    private var runtimeSamples: [Double] = []
     private let maxSamples = 30  // ca. 15–30 Sekunden bei 1–2 s Intervall
     private let maxPowerSamples = 60
+    private let maxRuntimeSamples = 60
+
+    private var lastChargeTime = Date()
+    private var wasCharging = false
 
     // Neuen Messwert hinzufügen
     func addSample(charge: (current: Int, max: Int)) {
@@ -61,5 +66,26 @@ final class BatteryHistory {
         print("DEBUG: avgPower = \(avgPower) W, drainPerHour = \(drainPerHour) %/h")
 
         return drainPerHour
+    }
+
+    // MARK: - Runtime Tracking
+
+    func addRuntimeSample(isCharging: Bool) {
+        if wasCharging && !isCharging {
+            lastChargeTime = Date()
+        }
+        wasCharging = isCharging
+
+        let hours = Date().timeIntervalSince(lastChargeTime) / 3600
+        runtimeSamples.append(hours)
+        if runtimeSamples.count > maxRuntimeSamples { runtimeSamples.removeFirst() }
+    }
+
+    func runtimeHistory() -> [Double] {
+        return runtimeSamples
+    }
+
+    func hoursSinceLastCharge() -> Double {
+        return Date().timeIntervalSince(lastChargeTime) / 3600
     }
 }

--- a/BatteryReader.swift
+++ b/BatteryReader.swift
@@ -85,4 +85,20 @@ final class BatteryReader {
             return "🔴"
         }
     }
+
+    /// Gibt zurück, ob der Akku gerade geladen wird
+    func isCharging() -> Bool? {
+        let service = IOServiceGetMatchingService(kIOMainPortDefault,
+                                                  IOServiceNameMatching("AppleSmartBattery"))
+        guard service != 0 else { return nil }
+        defer { IOObjectRelease(service) }
+
+        guard let any = IORegistryEntryCreateCFProperty(service,
+                                                         "IsCharging" as CFString,
+                                                         kCFAllocatorDefault, 0)?.takeRetainedValue(),
+              let num = any as? Int else {
+            return nil
+        }
+        return num != 0
+    }
 }


### PR DESCRIPTION
## Summary
- track runtime since last charge
- show runtime graph and label in the popover
- expose battery `isCharging` info

## Testing
- `swiftc AppDelegate.swift GraphView.swift BatteryHistory.swift BatteryReader.swift main.swift -o /tmp/out` *(fails: no such module 'Cocoa')*

------
https://chatgpt.com/codex/tasks/task_e_684ca1d5a350832580a359ebb891f2af